### PR TITLE
Segmentation fault fix.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include src/*.h

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: pyfarmhash
-Version: 0.1.4
+Version: 0.1.5
 Summary: Google FarmHash Bindings for Python
 Home-page: https://github.com/veelion/python-farmhash
 Author: Veelion Chong

--- a/PKG-INFO
+++ b/PKG-INFO
@@ -1,0 +1,61 @@
+Metadata-Version: 1.1
+Name: pyfarmhash
+Version: 0.1.4
+Summary: Google FarmHash Bindings for Python
+Home-page: https://github.com/veelion/python-farmhash
+Author: Veelion Chong
+Author-email: veelion@gmail.com
+License: UNKNOWN
+Description: python-farmhash
+        ==========
+        
+        
+        Overview
+        ========
+        This package provides bindings for the [Google's FarmHash](http://code.google.com/p/farmhash/).  
+        
+        Code specific to this project is covered by [The MIT License](http://opensource.org/licenses/MIT)
+        
+        Install
+        =======
+        Currently, clone the repo and:
+        > $ cd python-farmhash  
+        > $ sudo python setup.py Install  
+        
+        
+        The package was hosted on [PyPI](http://pypi.python.org/pypi/pyfarmhash)
+        
+        > $ pip install pyfarmhash  
+        > $ easy_install pyfarmhash  
+        
+        Usage
+        =====
+        The library is pretty simple to use:
+        
+        > import pyfarmhash as farmhash
+        > print farmhash.hash64('abc')  
+        > 2640714258260161385  
+        
+        For more details, use ipython:
+        > In [1]: import pyfarmhash as farmhash 
+        > 
+        > In [2]: farmhash.hash64withseed?  
+        > Type:       builtin_function_or_method  
+        > String Form:<built-in function hash64withseed>  
+        > Docstring:  
+        > Hash function for a string.  For convenience, a 64-bit seed is also hashed into the result.  
+        > example: print farmhash.hash64withseed('abc', 12345)  
+        > 13914286602242141520L  
+        
+        
+        
+        
+Platform: UNKNOWN
+Classifier: Development Status :: 5 - Production/Stable
+Classifier: License :: OSI Approved :: MIT License
+Classifier: Intended Audience :: Developers
+Classifier: Programming Language :: C
+Classifier: Programming Language :: Python
+Classifier: Programming Language :: Python :: 2.6
+Classifier: Programming Language :: Python :: 2.7
+Classifier: Programming Language :: Python :: 3.3

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ Currently, clone the repo and:
 > $ sudo python setup.py Install  
 
 
-The package will be hosted on [PyPI](http://pypi.python.org/pypi/farmhash)
+The package was hosted on [PyPI](http://pypi.python.org/pypi/pyfarmhash)
 
-> $ pip install farmhash  
-> $ easy_install farmhash  
+> $ pip install pyfarmhash  
+> $ easy_install pyfarmhash  
 
 Usage
 =====
 The library is pretty simple to use:
 
-> import farmhash  
+> import pyfarmhash as farmhash
 > print farmhash.hash64('abc')  
 > 2640714258260161385  
 
 For more details, use ipython:
-> In [1]: import farmhash  
+> In [1]: import pyfarmhash as farmhash 
 > 
 > In [2]: farmhash.hash64withseed?  
 > Type:       builtin_function_or_method  

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ Usage
 =====
 The library is pretty simple to use:
 
-> import pyfarmhash as farmhash
+> import farmhash
 > print farmhash.hash64('abc')  
 > 2640714258260161385  
 
 For more details, use ipython:
-> In [1]: import pyfarmhash as farmhash 
+> In [1]: import farmhash 
 > 
 > In [2]: farmhash.hash64withseed?  
 > Type:       builtin_function_or_method  

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[egg_info]
+tag_build = 
+tag_date = 0
+tag_svn_revision = 0
+

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,16 @@
 
 from setuptools import setup, find_packages, Extension
 
-VERSION = (0, 1, 0)
+VERSION = (0, 1, 5)
 
 setup(
-    name='farmhash',
+    name='pyfarmhash',
     version=".".join([str(x) for x in VERSION]),
     description="Google FarmHash Bindings for Python",
     long_description=open('README.md', 'r').read(),
+    data_files=[
+        'README.md',
+    ],
     author='Veelion Chong',
     author_email='veelion@gmail.com',
     url='https://github.com/veelion/python-farmhash',
@@ -19,7 +22,8 @@ setup(
         Extension('farmhash', [
             'src/farmhash.cc',
             'src/python-farmhash.cc'
-        ], extra_compile_args=["-O4"])
+        ], extra_compile_args=["-O4"]
+        )
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/src/python-farmhash.cc
+++ b/src/python-farmhash.cc
@@ -20,6 +20,9 @@
  * THE SOFTWARE.
  */
 
+//for backwards compatibility with python 2.x
+//This notifies python to use Py_ssize_t types with "s#" variables
+#define PY_SSIZE_T_CLEAN
 
 #include <iostream>
 #include <Python.h>
@@ -33,7 +36,7 @@ py_farmhash_Hash32(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
 
     if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
@@ -49,7 +52,7 @@ py_farmhash_Hash32WithSeed(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
     uint32_t seed;
 
     if (!PyArg_ParseTuple(args, "s#I", &s, &len, &seed))
@@ -66,7 +69,7 @@ py_farmhash_Hash64(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
 
     if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
@@ -87,7 +90,7 @@ py_farmhash_Hash64WithSeed(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
     uint64_t seed;
 
     if (!PyArg_ParseTuple(args, "s#K", &s, &len, &seed))
@@ -109,7 +112,7 @@ py_farmhash_Hash128(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
 
     if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
@@ -127,7 +130,7 @@ py_farmhash_Hash128WithSeed(PyObject *self, PyObject *args)
 {
     PyObject *result;
     const char *s;
-    size_t len;
+    Py_ssize_t len;
     uint64_t seedlow64;
     uint64_t seedhigh64;
 

--- a/src/python-farmhash.h
+++ b/src/python-farmhash.h
@@ -19,7 +19,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 static PyObject *py_farmhash_Hash32(PyObject *self, PyObject *args);


### PR DESCRIPTION
I pulled this copy from pypi and fixed a segmentation fault that was occuring for all hash functions due to the size_t type being used for length in python 2.7 (python 2.x passes in an int by default for s# vars). I modified the type to Py_ssize_t type to ensure compliance with 3.x and compatibility with 2.x. So this should work on 2.x and 3.x now without a problem.

Best,
Matt
