### PR TITLE
Python 3.4 compatability

### DIFF
--- a/src/python-farmhash.cc
+++ b/src/python-farmhash.cc
@@ -203,7 +203,7 @@ static struct PyModuleDef moduledef = {
 
 #define INITERROR return NULL
 
-PyObject *
+extern "C" PyObject *
 PyInit_farmhash(void)
 
 #else


### PR DESCRIPTION
Importing farmhash on python 3.4 results the following error:

```
Python 3.4.3 (default, Mar 26 2015, 22:03:40) 
[GCC 4.9.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import farmhash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: dynamic module does not define init function (PyInit_farmhash)
>>> 
```

Fixing it.
