### PR TITLE
Support farmhash for bytes-like objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ For more details, use ipython:
 > Type:       builtin_function_or_method  
 > String Form:<built-in function hash64withseed>  
 > Docstring:  
-> Hash function for a string.  For convenience, a 64-bit seed is also hashed into the result.  
+> Hash function for a bytes-like object.  For convenience, a 64-bit seed is also hashed into the result.  
 > example: print farmhash.hash64withseed('abc', 12345)  
 > 13914286602242141520L  
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages, Extension
 
-VERSION = (0, 3, 0)
+VERSION = (0, 4, 0)
 
 setup(
     name='pyfarmhash',
@@ -32,5 +32,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 )

--- a/src/python-farmhash.cc
+++ b/src/python-farmhash.cc
@@ -20,6 +20,8 @@
  * THE SOFTWARE.
  */
 
+// PY_SSIZE_T_CLEAN macro must be defined for '#' formats.
+#define PY_SSIZE_T_CLEAN
 
 #include <iostream>
 #include <Python.h>
@@ -35,10 +37,9 @@ py_farmhash_Hash32(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
 
-    len = strlen(s);
     uint32_t h = Hash32(s, len);
     result = Py_BuildValue("I", h);
 
@@ -53,10 +54,9 @@ py_farmhash_Hash32WithSeed(PyObject *self, PyObject *args)
     Py_ssize_t len;
     uint32_t seed;
 
-    if (!PyArg_ParseTuple(args, "sI", &s, &seed))
+    if (!PyArg_ParseTuple(args, "s#I", &s, &len, &seed))
         return NULL;
 
-    len = strlen(s);
     uint32_t h = Hash32WithSeed(s, len, seed);
     result = Py_BuildValue("I", h);
 
@@ -70,11 +70,9 @@ py_farmhash_Hash64(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
-    len = strlen(s);
 
-    len = strlen(s);
     uint64_t h = Hash64(s, len);
 # if __WORDSIZE == 64
     const char* int_param = "k";
@@ -94,10 +92,9 @@ py_farmhash_Hash64WithSeed(PyObject *self, PyObject *args)
     Py_ssize_t len;
     uint64_t seed;
 
-    if (!PyArg_ParseTuple(args, "sK", &s, &seed))
+    if (!PyArg_ParseTuple(args, "s#K", &s, &len, &seed))
         return NULL;
 
-    len = strlen(s);
     uint64_t h = Hash64WithSeed(s, len, seed);
 # if __WORDSIZE == 64
     const char* int_param = "k";
@@ -116,10 +113,9 @@ py_farmhash_Hash128(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
 
-    len = strlen(s);
     uint128_t h = Hash128(s, len);
     uint64_t low64 = Uint128Low64(h);
     uint64_t high64 = Uint128High64(h);
@@ -137,12 +133,11 @@ py_farmhash_Hash128WithSeed(PyObject *self, PyObject *args)
     uint64_t seedlow64;
     uint64_t seedhigh64;
 
-    if (!PyArg_ParseTuple(args, "sKK", &s, &seedlow64, &seedhigh64))
+    if (!PyArg_ParseTuple(args, "s#KK", &s, &len, &seedlow64, &seedhigh64))
         return NULL;
 
     //std::cout << "seed low64:" << seedlow64 << std::endl;
     //std::cout << "seed high64:" << seedhigh64 << std::endl;
-    len = strlen(s);
     uint128_t seed = Uint128(seedlow64, seedhigh64);
     uint128_t h = Hash128WithSeed(s, len, seed);
     uint64_t low64 = Uint128Low64(h);
@@ -159,10 +154,9 @@ py_farmhash_Fingerprint32(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
 
-    len = strlen(s);
     uint32_t h = Fingerprint32(s, len);
     result = Py_BuildValue("I", h);
 
@@ -176,11 +170,9 @@ py_farmhash_Fingerprint64(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
-    len = strlen(s);
 
-    len = strlen(s);
     uint64_t h = Fingerprint64(s, len);
 # if __WORDSIZE == 64
     const char* int_param = "k";
@@ -199,10 +191,9 @@ py_farmhash_Fingerprint128(PyObject *self, PyObject *args)
     const char *s;
     Py_ssize_t len;
 
-    if (!PyArg_ParseTuple(args, "s", &s))
+    if (!PyArg_ParseTuple(args, "s#", &s, &len))
         return NULL;
 
-    len = strlen(s);
     uint128_t h = Fingerprint128(s, len);
     uint64_t low64 = Uint128Low64(h);
     uint64_t high64 = Uint128High64(h);

--- a/src/python-farmhash.h
+++ b/src/python-farmhash.h
@@ -35,15 +35,15 @@ static PyObject *py_farmhash_Fingerprint128(PyObject *self, PyObject *args);
 
 PyMODINIT_FUNC initfarmhash(void);
 
-#define HASH32_DOCSTRING      "Hash function for a string.  Most useful in 32-bit binaries. \nexample: print farmhash.hash32('abc')\n2521517342"
-#define HASH32WITHSEED_DOCSTRING      "Hash function for a string.  For convenience, a 32-bit seed is also hashed into the result. \nexample: print farmhash.hash32withseed('abc', 1234)\n2521517342"
-#define HASH64_DOCSTRING      "Hash function for a string.  Returns an unsigned 64-bit integer. \nexample: print farmhash.hash64('abc')\n2640714258260161385L"
-#define HASH64WITHSEED_DOCSTRING      "Hash function for a string.  For convenience, a 64-bit seed is also hashed into the result. \nexample: print farmhash.hash64withseed('abc', 12345)\n13914286602242141520L"
-#define HASH128_DOCSTRING      "Hash function for a string.  Returns a tuple of two unsigned 64-bit integers: (low64, high64). \nexample: print farmhash.hash128('abc')\n(4143508125394299908L, 11566915719555882565L)"
-#define HASH128WITHSEED_DOCSTRING      "Hash function for a string. For convenience, two 32-bit seeds are also hashed into the result.\nexample: print farmhash.hash128withseed('abc', 1234, 0)\n(13364216625615136468L, 11320522948082609695L)"
-#define FINGERPRINT32_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a byte array.  Most useful in 32-bit binaries. \nexample: print farmhash.fingerprint32('abc')\n2521517342"
-#define FINGERPRINT64_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a byte array.  Returns an unsigned 64-bit integer. \nexample: print farmhash.fingerprint64('abc')\n2640714258260161385L"
-#define FINGERPRINT128_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a byte array.  Returns a tuple of two unsigned 64-bit integers: (low64, high64). \nexample: print farmhash.fingerprint128('abc')\n(13364216625615136468L, 11320522948082609695L)"
+#define HASH32_DOCSTRING      "Hash function for a bytes-like object.  Most useful in 32-bit binaries. \nexample: print farmhash.hash32('abc')\n2521517342"
+#define HASH32WITHSEED_DOCSTRING      "Hash function for a bytes-like object.  For convenience, a 32-bit seed is also hashed into the result. \nexample: print farmhash.hash32withseed('abc', 1234)\n2521517342"
+#define HASH64_DOCSTRING      "Hash function for a bytes-like object.  Returns an unsigned 64-bit integer. \nexample: print farmhash.hash64('abc')\n2640714258260161385L"
+#define HASH64WITHSEED_DOCSTRING      "Hash function for a bytes-like object.  For convenience, a 64-bit seed is also hashed into the result. \nexample: print farmhash.hash64withseed('abc', 12345)\n13914286602242141520L"
+#define HASH128_DOCSTRING      "Hash function for a bytes-like object.  Returns a tuple of two unsigned 64-bit integers: (low64, high64). \nexample: print farmhash.hash128('abc')\n(4143508125394299908L, 11566915719555882565L)"
+#define HASH128WITHSEED_DOCSTRING      "Hash function for a bytes-like object. For convenience, two 32-bit seeds are also hashed into the result.\nexample: print farmhash.hash128withseed('abc', 1234, 0)\n(13364216625615136468L, 11320522948082609695L)"
+#define FINGERPRINT32_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a bytes-like object.  Most useful in 32-bit binaries. \nexample: print farmhash.fingerprint32('abc')\n2521517342"
+#define FINGERPRINT64_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a bytes-like object.  Returns an unsigned 64-bit integer. \nexample: print farmhash.fingerprint64('abc')\n2640714258260161385L"
+#define FINGERPRINT128_DOCSTRING      "Fingerprint (i.e., good, portable, forever-fixed hash) function for a bytes-like object.  Returns a tuple of two unsigned 64-bit integers: (low64, high64). \nexample: print farmhash.fingerprint128('abc')\n(13364216625615136468L, 11320522948082609695L)"
 
 #if defined(__SUNPRO_C) || defined(__hpux) || defined(_AIX)
 #define inline


### PR DESCRIPTION
In the current version,
- farmhash does not support `bytes` in Python 3.  
For example, `farmhash.hash64(b'123')` will lead to  `TypeError: argument 1 must be str, not bytes`.
- It does not support strings containing embedded nulls as well.  
`farmhash.hash64('\x00')` will cause `ValueError: embedded null character`.

This PR enables the functionality to deal with bytes-like objects and strings containing embedded nulls. After this PR is merged, we can call farmhash functions as follows without error.
```python
farmhash.hash64('abc')  # 2640714258260161385
farmhash.hash64(b'abc')  # 2640714258260161385
farmhash.hash64('\x00')  # 13718060045003475796
farmhash.hash64(b'\x00')  # 13718060045003475796
```