### PR TITLE
Add script to build manylinux wheels

### DIFF
--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+docker run --rm -v "$(pwd)":/io quay.io/pypa/manylinux_2_34_x86_64 \
+    /bin/bash -c '
+    set -e
+    for PYBIN in /opt/python/cp{311,312,313}*/bin; do
+        "${PYBIN}/pip" wheel /io -w /tmp/wheels
+    done
+    auditwheel repair /tmp/wheels/*.whl -w /io/wheelhouse
+    chown -R '"$(id -u):$(id -g)"' /io/wheelhouse
+'

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -8,5 +8,4 @@ docker run --rm -v "$(pwd)":/io quay.io/pypa/manylinux_2_34_x86_64 \
         "${PYBIN}/pip" wheel /io -w /tmp/wheels
     done
     auditwheel repair /tmp/wheels/*.whl -w /io/wheelhouse
-    chown -R '"$(id -u):$(id -g)"' /io/wheelhouse
 '

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
As described in the title, this generates precompiled wheels for the packages, that can be used to avoid the requirement for g++ and for any compilation from the users.